### PR TITLE
Fixed an error in download_refseq.R and mk_subread_index.R

### DIFF
--- a/R/download_refseq.R
+++ b/R/download_refseq.R
@@ -76,6 +76,12 @@ download_refseq <- function(taxon, reference = TRUE, representative = FALSE,
 
   message(paste(taxon,"is a", rank_input, "under the", parent_kingdom, parent_rank))
   parent_kingdom <- tolower(parent_kingdom)
+  
+  # If parent kingdom is viruses, change it to be viral
+  if ("viruses" %in% parent_kingdom){
+    parent_kingdom <- "viral"
+  }
+
 
   # Download the assembly summary refseq table from NCBI
   ## which includes genome download link

--- a/R/mk_subread_index.R
+++ b/R/mk_subread_index.R
@@ -83,6 +83,6 @@ mk_subread_index <- function(ref_lib, split = 4, mem = 8000) {
     Rsubread::buildindex(basename = tools::file_path_sans_ext(ref_lib),
                          reference = ref_lib, memory = mem)
   }
-  return(paste(tools::file_path_sans_ext(lib), "_", seq_len(split_libs),
+  return(paste(tools::file_path_sans_ext(ref_lib), "_", seq_len(split_libs),
                sep = ""))
 }


### PR DESCRIPTION
An error occurred in download_refseq.R due to the viral kingdom being labeled Viruses in the NCBI taxonomy database whereas the virus folder on the ftp site is labeled as viral. I added an if statement to check whether the parent kingdom is viruses, and if true then the parent kingdom is changed to viral. 

An error occurred in the return statement in mk_subread_index.R in the return statement due to it referencing a variable not defined in its scope. I fixed this by changing the variable to one that was defined in the statement's scope.  
